### PR TITLE
Fix static ebb id initialization

### DIFF
--- a/src/app/AppEbb.cpp
+++ b/src/app/AppEbb.cpp
@@ -1,6 +1,3 @@
 #include "app/AppEbb.hpp"
 
-char ebb_id_resv __attribute__ ((section ("static_ebb_ids")));
-extern char static_ebb_ids_start[];
-ebbrt::Ebb<ebbrt::App> ebbrt::app_ebb __attribute__((init_priority (101))) =
-  Ebb<App>(static_cast<EbbId>(&ebb_id_resv - static_ebb_ids_start));
+char ebbrt::app_id_resv __attribute__ ((section ("static_ebb_ids")));

--- a/src/app/AppEbb.hpp
+++ b/src/app/AppEbb.hpp
@@ -8,7 +8,11 @@ namespace ebbrt {
   public:
     virtual void Start() = 0;
   };
-  extern Ebb<App> app_ebb;
+  extern char app_id_resv __attribute__ ((section ("static_ebb_ids")));
+  extern "C" char static_ebb_ids_start[];
+  const Ebb<App> app_ebb =
+    Ebb<App>(static_cast<EbbId>(&app_id_resv -
+                                static_ebb_ids_start));
 }
 
 #endif

--- a/src/ebb/EbbAllocator/EbbAllocator.cpp
+++ b/src/ebb/EbbAllocator/EbbAllocator.cpp
@@ -1,8 +1,3 @@
 #include "ebb/EbbAllocator/EbbAllocator.hpp"
 
-char ebb_allocator_id_resv __attribute__ ((section ("static_ebb_ids")));
-extern char static_ebb_ids_start[];
-ebbrt::Ebb<ebbrt::EbbAllocator> ebbrt::ebb_allocator
-__attribute__((init_priority (101))) =
-  ebbrt::Ebb<EbbAllocator>(static_cast<ebbrt::EbbId>
-                              (&ebb_allocator_id_resv - static_ebb_ids_start));
+char ebbrt::ebb_allocator_id_resv __attribute__ ((section ("static_ebb_ids")));

--- a/src/ebb/EbbAllocator/EbbAllocator.hpp
+++ b/src/ebb/EbbAllocator/EbbAllocator.hpp
@@ -8,7 +8,12 @@ namespace ebbrt {
   public:
     virtual void CacheRep(EbbId id, EbbRep* rep) = 0;
   };
-  extern Ebb<EbbAllocator> ebb_allocator;
+  extern char ebb_allocator_id_resv
+  __attribute__ ((section ("static_ebb_ids")));
+  extern "C" char static_ebb_ids_start[];
+  const Ebb<EbbAllocator> ebb_allocator =
+    Ebb<EbbAllocator>(static_cast<EbbId>(&ebb_allocator_id_resv -
+                                         static_ebb_ids_start));
 }
 
 #endif

--- a/src/ebb/MemoryAllocator/MemoryAllocator.cpp
+++ b/src/ebb/MemoryAllocator/MemoryAllocator.cpp
@@ -1,8 +1,3 @@
 #include "ebb/MemoryAllocator/MemoryAllocator.hpp"
 
-char mem_allocator_id_resv __attribute__ ((section ("static_ebb_ids")));
-extern char static_ebb_ids_start[];
-const ebbrt::Ebb<ebbrt::MemoryAllocator> ebbrt::memory_allocator
-__attribute__((init_priority (101))) =
-  ebbrt::Ebb<MemoryAllocator>(static_cast<ebbrt::EbbId>
-                     (&mem_allocator_id_resv - static_ebb_ids_start));
+char ebbrt::mem_allocator_id_resv __attribute__ ((section ("static_ebb_ids")));

--- a/src/ebb/MemoryAllocator/MemoryAllocator.hpp
+++ b/src/ebb/MemoryAllocator/MemoryAllocator.hpp
@@ -12,7 +12,12 @@ namespace ebbrt {
     virtual void* realloc(void* ptr, size_t size) = 0;
     virtual void* calloc(size_t num, size_t size) = 0;
   };
-  extern const Ebb<MemoryAllocator> memory_allocator;
+  extern char mem_allocator_id_resv
+  __attribute__ ((section ("static_ebb_ids")));
+  extern "C" char static_ebb_ids_start[];
+  const Ebb<MemoryAllocator> memory_allocator =
+    Ebb<MemoryAllocator>(static_cast<EbbId>(&mem_allocator_id_resv -
+                                            static_ebb_ids_start));
 }
 
 #endif

--- a/src/lrt/trans.hpp
+++ b/src/lrt/trans.hpp
@@ -15,7 +15,7 @@ namespace ebbrt {
        *
        * @param num_cores
        *
-       * @return 
+       * @return
        */
       bool init(unsigned num_cores);
       /**
@@ -23,7 +23,7 @@ namespace ebbrt {
        */
       void init_ebbs();
       /**
-       * @brief Per-core initilization 
+       * @brief Per-core initilization
        */
       void init_cpu();
       /**
@@ -47,20 +47,20 @@ namespace ebbrt {
          * @brief Initial stage of ebb call
          *
          * @param args Ebbcall arguments
-         * @param fnum 
-         * @param fret 
+         * @param fnum
+         * @param fret
          * @param id
          *
-         * @return 
+         * @return
          */
         virtual bool PreCall(Args* args, ptrdiff_t fnum,
                              FuncRet* fret, EbbId id) = 0;
         /**
-         * @brief Final stage of ebb call 
+         * @brief Final stage of ebb call
          s
          * @param ret
          *
-         * @return 
+         * @return
          */
         virtual void* PostCall(void* ret) = 0;
 
@@ -68,7 +68,7 @@ namespace ebbrt {
       };
 
       /**
-       * @brief 
+       * @brief
        */
       class EbbRep {
       };
@@ -85,7 +85,7 @@ namespace ebbrt {
       };
 
       /**
-       * @brief Elasic Building Block template 
+       * @brief Elasic Building Block template
        */
       template <class T>
       class Ebb {


### PR DESCRIPTION
This commit puts static ebb id construction into the header where the
ebbs are declared. This guarantees that the constructor which figures
out the id is guaranteed to execute before any code that wants to use
it because of the ordering within a translation unit
