### PR TITLE
first pexpect script runs bare metal hello world

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ignore emacs backup files
+*~
+
 # Compiled Object files
 *.slo
 *.lo

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+if HAVE_PYTHON
+TESTS_ENVIRONMENT = python
+if LRT_ULNX
+#TESTS = test/hello-bare.py
+endif
+if LRT_BARE
+TESTS = test/hello-bare.py
+endif
+endif
+
 AM_CXXFLAGS = -std=c++0x -Wall -Werror
 AM_CPPFLAGS = -iquote $(top_srcdir)/src \
 	--include $(top_builddir)/config.h

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,8 @@ AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror -Wno-portability])
 AC_CONFIG_SRCDIR([src/ebbrt.hpp])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_FILES([Makefile])
+AM_PATH_PYTHON([2.6],, [:])
+AM_CONDITIONAL([HAVE_PYTHON], [test "$PYTHON" != ":"])
 
 m4_include([m4/doxy.m4])
 DX_HTML_FEATURE(ON)

--- a/test/hello-bare.py
+++ b/test/hello-bare.py
@@ -1,0 +1,18 @@
+import pexpect
+import multiprocessing
+import sys
+
+cores = multiprocessing.cpu_count()
+for z in range(1, cores+1):
+    sys.stdout.write( "bindtst on " + str(z) + " cores [")
+    sys.stdout.flush()
+    child = pexpect.spawn ('qemu-system-x86_64 -nographic -smp ' + str(z) + ' src/app/HelloWorld/HelloWorld.iso')
+    # uncomment following line to see results of experiment
+    #  child.logfile = sys.stdout
+    for j in range(z):
+        child.expect('Hello World', timeout=100)
+    # child.kill(9)
+    child.sendcontrol('a')
+    child.send('x')
+    child.wait()
+    print "]"


### PR DESCRIPTION
Modified Makefile.am to run python expect scripts for tests
added rule in gitignore to ignore emacs backup files
script hello-bare.py runs through all the bare metal runs of hello world for
number of cores we have
