### PR TITLE
Reverted back to using a complex type as a return value for ebbrt::fox::Hash::get method

### DIFF
--- a/src/app/LibFox/ebbs.cpp
+++ b/src/app/LibFox/ebbs.cpp
@@ -57,8 +57,8 @@ ebbrt::fox::Hash::set(const char *key, EbbRef<ebbrt::fox::Object> o)
   TRACE;
 }
 
-void
-ebbrt::fox::Hash::get(const char * key, EbbRef<ebbrt::fox::Object> *o)
+ebbrt::lrt::trans::EbbRef<ebbrt::fox::Object>
+ebbrt::fox::Hash::get(const char * key)
 {
   TRACE;
 #if 0
@@ -71,9 +71,9 @@ ebbrt::fox::Hash::get(const char * key, EbbRef<ebbrt::fox::Object> *o)
 
   std::unordered_map<std::string,EbbRef<Object>>::const_iterator got = map.find(key);
   if ( got == map.end() )
-    *o = EbbRef<Object>(NULLID);
+    return EbbRef<Object>(NULLID);
   else
-    *o = got->second;
+    return got->second;
 }
 
 ebbrt::EbbRoot*

--- a/src/app/LibFox/ebbs.hpp
+++ b/src/app/LibFox/ebbs.hpp
@@ -43,7 +43,7 @@ namespace ebbrt {
 
     class Dictionary : public Object {
     public:
-      virtual void get(const char *key, EbbRef<Object> *obj) = 0;
+      virtual EbbRef<Object> get(const char *key) = 0;
       virtual void set(const char *key, EbbRef<Object> obj) = 0;
     };
 
@@ -98,7 +98,7 @@ namespace ebbrt {
     public:
       static EbbRoot * ConstructRoot();
       Hash();
-      virtual void get(const char *key, EbbRef<Object> *obj) override;
+      virtual EbbRef<Object> get(const char *key) override;
       virtual void set(const char *key, EbbRef<Object> obj) override;
     };
 

--- a/src/app/LibFox/libfoxME.cpp
+++ b/src/app/LibFox/libfoxME.cpp
@@ -78,8 +78,7 @@ fox_set(fox_ptr fhand,
         const char *value, size_t value_sz)
 {
   TRACE;
-  ebbrt::EbbRef<ebbrt::fox::Object> o;
-  ebbrt::fox::theHash->get(key, &o);
+  ebbrt::EbbRef<ebbrt::fox::Object> o = ebbrt::fox::theHash->get(key);
 
   if (o != ebbrt::EbbRef<ebbrt::fox::Object>(ebbrt::NULLID)) assert(0); // should not exist yet
   
@@ -98,8 +97,7 @@ fox_get(fox_ptr fhand,
         char **pvalue, size_t *pvalue_sz)
 {
   TRACE;
-  ebbrt::EbbRef<ebbrt::fox::Object> o;
-  ebbrt::fox::theHash->get(key, &o);
+  ebbrt::EbbRef<ebbrt::fox::Object> o =  ebbrt::fox::theHash->get(key);
   if (o != ebbrt::EbbRef<ebbrt::fox::Object>(ebbrt::NULLID)) {
     o->getValue(pvalue, pvalue_sz);
   } else {
@@ -128,7 +126,7 @@ fox_sync_set(fox_ptr fhand, unsigned delta,
   //FIXME: no semaphore stuff
   TRACE;
   assert(strcmp(key,STR_TASK_SYNC)==0);
-  //  assert(ebbrt::fox::theTaskSync == static_cast<ebbrt::EbbRef<ebbrt::fox::Sync>>(ebbrt::fox::theHash->get(key)));
+  assert(ebbrt::fox::theTaskSync == static_cast<ebbrt::EbbRef<ebbrt::fox::Sync>>(ebbrt::fox::theHash->get(key)));
   ebbrt::fox::theTaskSync->enter((void *)__func__);
   return 0;
 }
@@ -159,11 +157,7 @@ fox_broad_set(fox_ptr fhand,
   TRACE;
   assert(dic != rw);
   assert(strcmp(key,STR_RDDATA)==0);
-  {
-    ebbrt::lrt::trans::EbbRef<ebbrt::fox::Object> o;
-    ebbrt::fox::theHash->get(key, &o);
-  }
-  //  assert(ebbrt::fox::theRDData == static_cast<ebbrt::EbbRef<ebbrt::fox::RDData>>(ebbrt::fox::theHash->get(key)));
+  assert(ebbrt::fox::theRDData == static_cast<ebbrt::EbbRef<ebbrt::fox::RDData>>(ebbrt::fox::theHash->get(key)));
   ebbrt::fox::theRDData->set(value, value_sz);
   return 0;
 }


### PR DESCRIPTION
Since we now have a workaround in the miss code for this scenario the method now returns a EbbRef
tested on kd with gcc
tested on bg frontends with gcc and llvm
