### PR TITLE
feat(messenger): preallocated message buffer

### DIFF
--- a/baremetal/src/Messenger.cc
+++ b/baremetal/src/Messenger.cc
@@ -95,8 +95,6 @@ void ebbrt::Messenger::Connection::Receive(std::unique_ptr<MutIOBuf> b) {
       auto ratio = (double)buffer_len / (double)capacity;
       if (ratio < occupancy_ratio_) {
         // allocate message buffer and coalesce chain
-        //kprintf("Messanger: low payload occupancy ratio %f (%d/%d), " "coalescing...\n",
-        //        chain_len, message_len, ratio);
         auto newbuf = MakeUniqueIOBuf(message_len, false);
         auto dp = newbuf->GetMutDataPointer();
         for (auto& buf : *buf_) {
@@ -105,9 +103,9 @@ void ebbrt::Messenger::Connection::Receive(std::unique_ptr<MutIOBuf> b) {
           dp.Advance(len);
           preallocate_ += len;
         }
-        assert(newbuf.CountChainElements() == 1);
-        assert(newbuf.ComputeChainDataLenght() == message_len);
-        assert(preallocate == chain_len);
+        assert(newbuf->CountChainElements() == 1);
+        assert(newbuf->ComputeChainDataLength() == message_len);
+        assert(preallocate_ == buffer_len);
         buf_ = std::move(newbuf);
       }
     }

--- a/baremetal/src/Messenger.cc
+++ b/baremetal/src/Messenger.cc
@@ -19,9 +19,9 @@ ebbrt::Messenger::Connection::Connection(ebbrt::NetworkManager::TcpPcb pcb)
 void ebbrt::Messenger::Connection::preallocated(std::unique_ptr<MutIOBuf> b) {
 
   auto len = b->Length();
-  buf_->Advance(preallocate_);
-  std::memcpy(reinterpret_cast<void*>(buf_->MutData()), b->Data(), len);
-  buf_->Retreat(preallocate_);
+  auto ptr = buf_->MutData();
+  ptr += preallocate_;
+  std::memcpy(reinterpret_cast<void*>(ptr), b->Data(), len);
 
   auto dp = buf_->GetMutDataPointer();
   preallocate_ += len;

--- a/baremetal/src/Messenger.cc
+++ b/baremetal/src/Messenger.cc
@@ -31,13 +31,11 @@ void ebbrt::Messenger::Connection::preallocated(std::unique_ptr<MutIOBuf> b) {
   if (preallocate_ == message_len) {
     kassert(buf_->Length() == message_len);
     // pass along received message
-    std::unique_ptr<MutIOBuf> msg;
-    msg = std::move(buf_);
     preallocate_ = 0;
-    msg->AdvanceChain(sizeof(Header));
+    buf_->AdvanceChain(sizeof(Header));
     auto& ref = GetMessagableRef(header.id, header.type_code);
     ref.ReceiveMessageInternal(NetworkId(Pcb().GetRemoteAddress()),
-                               std::move(msg));
+                               std::move(buf_));
   }
   kassert(preallocate_ <= message_len);
   return;
@@ -75,12 +73,10 @@ void ebbrt::Messenger::Connection::Receive(std::unique_ptr<MutIOBuf> b) {
 
   // pass message along, or buffer partial message
   if (likely(buffer_len == message_len)) {
-    std::unique_ptr<MutIOBuf> msg;
-    msg = std::move(buf_);
-    msg->AdvanceChain(sizeof(Header));
+    buf_->AdvanceChain(sizeof(Header));
     auto& ref = GetMessagableRef(header.id, header.type_code);
     ref.ReceiveMessageInternal(NetworkId(Pcb().GetRemoteAddress()),
-                               std::move(msg));
+                               std::move(buf_));
   } else if (buffer_len > message_len) {
     many_payloads(std::move(b));
   } else {

--- a/baremetal/src/Messenger.cc
+++ b/baremetal/src/Messenger.cc
@@ -10,8 +10,6 @@
 #include <ebbrt/UniqueIOBuf.h>
 
 uint16_t ebbrt::Messenger::port_;
-double ebbrt::Messenger::Connection::occupancy_ratio_ = 0.2;
-uint8_t ebbrt::Messenger::Connection::preallocate_chain_len_ = 100;
 
 ebbrt::Messenger::Messenger() {}
 
@@ -87,13 +85,13 @@ void ebbrt::Messenger::Connection::Receive(std::unique_ptr<MutIOBuf> b) {
     many_payloads(std::move(b));
   } else {
     // preallocate buffer if payload occupancy ratio drops below threshold
-    if (buf_->CountChainElements() % preallocate_chain_len_ == 0) {
+    if (buf_->CountChainElements() % kPreallocateChainLen == 0) {
       size_t capacity = 0;
       for (auto& buf : *buf_) {
         capacity += buf.Capacity();
       }
       auto ratio = (double)buffer_len / (double)capacity;
-      if (ratio < occupancy_ratio_) {
+      if (ratio < kOccupancyRatio) {
         // allocate message buffer and coalesce chain
         auto newbuf = MakeUniqueIOBuf(message_len, false);
         auto dp = newbuf->GetMutDataPointer();

--- a/baremetal/src/Messenger.cc
+++ b/baremetal/src/Messenger.cc
@@ -10,103 +10,109 @@
 #include <ebbrt/UniqueIOBuf.h>
 
 uint16_t ebbrt::Messenger::port_;
+double ebbrt::Messenger::Connection::occupancy_ratio_ = 0.2;
+uint8_t ebbrt::Messenger::Connection::preallocate_chain_len_ = 100;
 
 ebbrt::Messenger::Messenger() {}
 
 ebbrt::Messenger::Connection::Connection(ebbrt::NetworkManager::TcpPcb pcb)
     : TcpHandler(std::move(pcb)) {}
 
-void ebbrt::Messenger::Connection::Receive(std::unique_ptr<MutIOBuf> b) {
-  kassert(b->Length() != 0);
-  // If we already have queued data append this new data to the end
-  if (buf_) {
-    buf_->PrependChain(std::move(b));
-  } else {
-    buf_ = std::move(b);
-  }
+void ebbrt::Messenger::Connection::preallocated(std::unique_ptr<MutIOBuf> b) {
 
-  // process buffer chain
-  while (buf_) {
-    auto chain_len = buf_->ComputeChainDataLength();
-    // Do we have enough data for a header?
-    if (chain_len < sizeof(Header))
-      return;
+  auto len = b->Length();
+  buf_->Advance(preallocate_);
+  std::memcpy(reinterpret_cast<void*>(buf_->MutData()), b->Data(), len);
+  buf_->Retreat(preallocate_);
 
-    auto dp = buf_->GetDataPointer();
-    auto& header = dp.Get<Header>();
-    auto message_len = sizeof(Header) + header.length;
+  auto dp = buf_->GetMutDataPointer();
+  preallocate_ += len;
+  auto& header = dp.Get<Header>();
+  auto message_len = sizeof(Header) + header.length;
 
+  if (preallocate_ == message_len) {
+    kassert(buf_->Length() == message_len);
+    // pass along received message
     std::unique_ptr<MutIOBuf> msg;
-    if (likely(chain_len == message_len)) {
-      // We have a full message
-      msg = std::move(buf_);
-    } else if (chain_len > message_len) {
-      // Handle the case when we've received multiple message in our buffer
-      // chain
-      //
-      // After this loop msg should hold exactly one message and everything
-      // else will be in buf_
-      bool first = true;
-      msg = std::move(buf_);
-      for (auto& buf : *msg) {
-        // for each buffer
-        auto buf_len = buf.Length();
-        if (buf_len == message_len) {
-          // If the first buffer contains the full message
-          // Move the remainder of chain into buf_, while our message remains
-          // in msg_
-          buf_ = std::unique_ptr<MutIOBuf>(
-              static_cast<MutIOBuf*>(msg->UnlinkEnd(*buf.Next()).release()));
-          break;
-        } else if (buf_len > message_len) {
-          // Here we need to split the buffer
-          std::unique_ptr<MutIOBuf> end;
-          if (first) {
-            end = std::move(msg);
-          } else {
-            auto tmp_end =
-                static_cast<MutIOBuf*>(msg->UnlinkEnd(buf).release());
-            end = std::unique_ptr<MutIOBuf>(tmp_end);
-          }
-
-          auto remainder = end->Pop();
-
-          // make a reference counted IOBuf to the end
-          auto rc_end = IOBuf::Create<MutSharedIOBufRef>(
-              SharedIOBufRef::CloneView, std::move(end));
-          // create a copy (increments ref count)
-          buf_ = IOBuf::Create<MutSharedIOBufRef>(SharedIOBufRef::CloneView,
-                                                  *rc_end);
-
-          // trim and append to msg
-          rc_end->TrimEnd(buf_len - message_len);
-          if (first) {
-            msg = std::move(rc_end);
-          } else {
-            msg->PrependChain(std::move(rc_end));
-          }
-
-          // advance and attach remainder to
-          buf_->Advance(message_len);
-          if (remainder)
-            buf_->PrependChain(std::move(remainder));
-          break;
-        }
-        message_len -= buf_len;
-        first = false;
-      }
-    } else {
-      // since message_len > chain_len we wait for more data
-      return;
-    }
-
-    // msg now holds exactly one message
-    // trim the header
+    msg = std::move(buf_);
+    preallocate_ = 0;
     msg->AdvanceChain(sizeof(Header));
     auto& ref = GetMessagableRef(header.id, header.type_code);
     ref.ReceiveMessageInternal(NetworkId(Pcb().GetRemoteAddress()),
                                std::move(msg));
   }
+  kassert(preallocate_ <= message_len);
+  return;
+}
+
+void ebbrt::Messenger::Connection::many_payloads(std::unique_ptr<MutIOBuf> b) {
+  // FIXME: Support for multiple messages in a payload
+  EBBRT_UNIMPLEMENTED();
+  return;
+}
+
+void ebbrt::Messenger::Connection::Receive(std::unique_ptr<MutIOBuf> b) {
+  kassert(b->Length() != 0);
+  kassert(b->IsChained() == false);
+
+  // processes preallocated message buffer
+  if (preallocate_) {
+    preallocated(std::move(b));
+    return;
+  }
+  // process buffer chain
+  if (buf_) {
+    buf_->PrependChain(std::move(b));
+  } else {
+    buf_ = std::move(b);
+  }
+  // process message
+  auto buffer_len = buf_->ComputeChainDataLength();
+  if (buffer_len < sizeof(Header)) {
+    return;
+  }
+  auto dp = buf_->GetDataPointer();
+  auto& header = dp.Get<Header>();
+  auto message_len = sizeof(Header) + header.length;
+
+  // pass message along, or buffer partial message
+  if (likely(buffer_len == message_len)) {
+    std::unique_ptr<MutIOBuf> msg;
+    msg = std::move(buf_);
+    msg->AdvanceChain(sizeof(Header));
+    auto& ref = GetMessagableRef(header.id, header.type_code);
+    ref.ReceiveMessageInternal(NetworkId(Pcb().GetRemoteAddress()),
+                               std::move(msg));
+  } else if (buffer_len > message_len) {
+    many_payloads(std::move(b));
+  } else {
+    // preallocate buffer if payload occupancy ratio drops below threshold
+    if (buf_->CountChainElements() % preallocate_chain_len_ == 0) {
+      size_t capacity = 0;
+      for (auto& buf : *buf_) {
+        capacity += buf.Capacity();
+      }
+      auto ratio = (double)buffer_len / (double)capacity;
+      if (ratio < occupancy_ratio_) {
+        // allocate message buffer and coalesce chain
+        //kprintf("Messanger: low payload occupancy ratio %f (%d/%d), " "coalescing...\n",
+        //        chain_len, message_len, ratio);
+        auto newbuf = MakeUniqueIOBuf(message_len, false);
+        auto dp = newbuf->GetMutDataPointer();
+        for (auto& buf : *buf_) {
+          auto len = buf.Length();
+          std::memcpy(reinterpret_cast<void*>(dp.Data()), buf.Data(), len);
+          dp.Advance(len);
+          preallocate_ += len;
+        }
+        assert(newbuf.CountChainElements() == 1);
+        assert(newbuf.ComputeChainDataLenght() == message_len);
+        assert(preallocate == chain_len);
+        buf_ = std::move(newbuf);
+      }
+    }
+  }
+  return;
 }
 
 void ebbrt::Messenger::Connection::Connected() { promise_.SetValue(this); }

--- a/baremetal/src/include/ebbrt/Messenger.h
+++ b/baremetal/src/include/ebbrt/Messenger.h
@@ -75,6 +75,12 @@ class Messenger : public StaticSharedEbb<Messenger>, public CacheAligned {
     Future<Connection*> GetFuture();
 
    private:
+    static double occupancy_ratio_;
+    static uint8_t preallocate_chain_len_;
+    void preallocated(std::unique_ptr<ebbrt::MutIOBuf> buf);
+    void many_payloads(std::unique_ptr<ebbrt::MutIOBuf> buf);
+
+    uint32_t preallocate_;
     std::unique_ptr<ebbrt::MutIOBuf> buf_;
     ebbrt::Promise<Connection*> promise_;
   };

--- a/baremetal/src/include/ebbrt/Messenger.h
+++ b/baremetal/src/include/ebbrt/Messenger.h
@@ -75,8 +75,8 @@ class Messenger : public StaticSharedEbb<Messenger>, public CacheAligned {
     Future<Connection*> GetFuture();
 
    private:
-    static double occupancy_ratio_;
-    static uint8_t preallocate_chain_len_;
+    static const constexpr double kOccupancyRatio = 0.20;
+    static const constexpr uint8_t kPreallocateChainLen = 100;
     void preallocated(std::unique_ptr<ebbrt::MutIOBuf> buf);
     void many_payloads(std::unique_ptr<ebbrt::MutIOBuf> buf);
 

--- a/hosted/src/Messenger.cc
+++ b/hosted/src/Messenger.cc
@@ -89,7 +89,9 @@ void ebbrt::Messenger::DoAccept(
 uint16_t ebbrt::Messenger::GetPort() { return port_; }
 
 ebbrt::Messenger::Session::Session(bai::tcp::socket socket)
-    : socket_(std::move(socket)) {}
+    : socket_(std::move(socket)) {
+      socket_.set_option(boost::asio::ip::tcp::no_delay(true));
+}
 
 void ebbrt::Messenger::Session::Start() { ReadHeader(); }
 


### PR DESCRIPTION
Adds a feature that will check the payload occupancy of long chains (%100 len) and will preallocate a message buffer when the payload occupancy drops below 20%. The prevents very long IOBuf chains that, because of our fixed sized IO buffers, consume large amounts of unnecessary memoryy.

For simplicity, I've removed the logic to extract multiple message payloads from a single IOBuf, and replaced it with an EBBRT_UNIMPLEMENTED. The code can be restored from git history if/when we want to stream-or-batch messages (the current interface, SendMessage, is sequential ). 