### PR TITLE
fix(leak): Ensure MovableFunction destruction

### DIFF
--- a/baremetal/src/EventManager.cc
+++ b/baremetal/src/EventManager.cc
@@ -196,8 +196,12 @@ SaveContextAndSwitch(uintptr_t first_param, uintptr_t stack,
 
 void ebbrt::EventManager::CallSync(uintptr_t mgr) {
   auto pmgr = reinterpret_cast<EventManager*>(mgr);
-  auto fn = std::move(pmgr->sync_spawn_fn_);
-  pmgr->InvokeFunction(fn);
+  // TRICKY: This function does not terminate, so we must ensure we
+  // destroy any local variables (hence the local scope here)
+  {
+    auto fn = std::move(pmgr->sync_spawn_fn_);
+    pmgr->InvokeFunction(fn);
+  }
   // In the case that the event blocked, it will only be reactivated on a
   // "fresh" event. Therefore if the sync_contexts_ stack is empty, we just go
   // back to the event loop

--- a/common/src/include/ebbrt/MoveLambda.h
+++ b/common/src/include/ebbrt/MoveLambda.h
@@ -12,6 +12,7 @@ template <typename ReturnType, typename... ParamTypes>
 class MovableFunctionBase {
  public:
   virtual ReturnType CallFunc(ParamTypes... p) = 0;
+  virtual ~MovableFunctionBase() {}
 };
 
 template <typename F, typename ReturnType, typename... ParamTypes>


### PR DESCRIPTION
MovableFunctions were not getting appropriately destroyed due to the
lack of a virtual destruction in the MovableFunctionBase. Additionally
commit d2e5848 introduced another leak where a synchronously invoked
function (via SpawnLocal) was not getting destroyed because the CallSync
function never terminates.