### PR TITLE
NodeAllocator accepts optional string of arguments

### DIFF
--- a/hosted/src/NodeAllocator.cc
+++ b/hosted/src/NodeAllocator.cc
@@ -26,7 +26,7 @@ std::string ebbrt::NodeAllocator::DefaultArguments;
 
 ebbrt::NodeAllocator::Session::Session(bai::tcp::socket socket,
                                        uint32_t net_addr)
-  : socket_(std::move(socket)), net_addr_(net_addr) { }
+    : socket_(std::move(socket)), net_addr_(net_addr) {}
 
 namespace {
 class IOBufToCBS {
@@ -95,19 +95,19 @@ void ebbrt::NodeAllocator::Session::Start() {
 ebbrt::NodeAllocator::NodeAllocator() : node_index_(2), allocation_index_(0) {
   dir_[0] = 0;
   {
-    char *str =getenv("EBBRT_NODE_ALLOCATOR_DEFAULT_CPUS");
+    char* str = getenv("EBBRT_NODE_ALLOCATOR_DEFAULT_CPUS");
     DefaultCpus = (str) ? atoi(str) : kDefaultCpus;
     str = getenv("EBBRT_NODE_ALLOCATOR_DEFAULT_RAM");
     DefaultRam = (str) ? atoi(str) : kDefaultRam;
     str = getenv("EBBRT_NODE_ALLOCATOR_DEFAULT_NUMANODES");
     DefaultNumaNodes = (str) ? atoi(str) : kDefaultNumaNodes;
-    str  = getenv("EBBRT_NODE_ALLOCATOR_DEFAULT_ARGUMENTS");
+    str = getenv("EBBRT_NODE_ALLOCATOR_DEFAULT_ARGUMENTS");
     DefaultArguments = (str) ? std::string(str) : std::string(" ");
 
-    std::cout << "NodeAllocator::Init() DefaultCpus=" << DefaultCpus 
-	      << " DefaultNumaNodes=" << DefaultNumaNodes 
-	    << " DefaultRam=" << DefaultRam 
-      << " DefaultArguments="<< DefaultArguments << std::endl;
+    std::cout << "NodeAllocator::Init() DefaultCpus=" << DefaultCpus
+              << " DefaultNumaNodes=" << DefaultNumaNodes
+              << " DefaultRam=" << DefaultRam
+              << " DefaultArguments=" << DefaultArguments << std::endl;
   }
   auto acceptor = std::make_shared<bai::tcp::acceptor>(
       active_context->io_service_, bai::tcp::endpoint(bai::tcp::v4(), 0));
@@ -138,10 +138,11 @@ ebbrt::NodeAllocator::NodeAllocator() : node_index_(2), allocation_index_(0) {
 ebbrt::NodeAllocator::~NodeAllocator() {
   if (dir_[0]) {
     std::cout << "OUTPUT FROM NODES: " << std::endl;
-    std::string cmd  = "/bin/cat " + std::string(dir_) + "/*/stdout";
+    std::string cmd = "/bin/cat " + std::string(dir_) + "/*/stdout";
     int rc = system(cmd.c_str());
     if (rc < 0) {
-      std::cout << "ERROR: system rc =" << rc << " for command: " << cmd << std::endl;
+      std::cout << "ERROR: system rc =" << rc << " for command: " << cmd
+                << std::endl;
     }
   }
   std::cout << "Node Allocator destructor! " << std::endl;
@@ -170,12 +171,9 @@ ebbrt::NodeAllocator::DoAccept(std::shared_ptr<bai::tcp::acceptor> acceptor,
 }
 
 ebbrt::NodeAllocator::NodeDescriptor
-ebbrt::NodeAllocator::AllocateNode(std::string binary_path,
-				   int cpus,
-				   int numaNodes,
-				   int ram, 
-           std::string arguments) 
-{
+ebbrt::NodeAllocator::AllocateNode(std::string binary_path, int cpus,
+                                   int numaNodes, int ram,
+                                   std::string arguments) {
   auto fdt = Fdt();
   fdt.BeginNode("/");
   fdt.BeginNode("runtime");
@@ -214,16 +212,15 @@ ebbrt::NodeAllocator::AllocateNode(std::string binary_path,
   char network[100];
   snprintf(network, sizeof(network), "%d", network_id_);
 
-  std::string command = "/opt/khpy/kh alloc" +
-    std::string(" --ram ") + std::to_string(ram)  +
-    std::string(" --cpu ") + std::to_string(cpus) +
-    std::string(" --numa ") + std::to_string(numaNodes) +
+  std::string command =
+      "/opt/khpy/kh alloc" + std::string(" --ram ") + std::to_string(ram) +
+      std::string(" --cpu ") + std::to_string(cpus) + std::string(" --numa ") +
+      std::to_string(numaNodes) +
 #ifndef NDEBUG
-    " -g" +
+      " -g" +
 #endif
-    std::string(" ") + arguments +
-    std::string(" ") + std::string(network) + " " +
-    binary_path + " " + fname.native();
+      std::string(" ") + arguments + std::string(" ") + std::string(network) +
+      " " + binary_path + " " + fname.native();
 
   std::cout << "executing " << command << std::endl;
   auto f = popen(command.c_str(), "r");
@@ -245,17 +242,17 @@ ebbrt::NodeAllocator::AllocateNode(std::string binary_path,
   auto num = std::stoi(num_str);
   std::cout << num << std::endl;
 
-  if (dir_[0]==0)   {
+  if (dir_[0] == 0) {
     std::string line;
-    while (std::getline(input, line)) { 
+    while (std::getline(input, line)) {
       unsigned found = line.find_last_of("/\\");
-      if ( found && line.substr(found+1) == std::string("stdout") ) {
-        std::string dir = line.substr(0,found);
-	found =  dir.find_last_of("/\\");
-	bzero(dir_, sizeof(dir_));
-	strncpy(dir_, line.substr(0,found).c_str(), sizeof(dir_));
-	dir_[sizeof(dir_)]=0;
-	printf("dir: %s\n", dir_);
+      if (found && line.substr(found + 1) == std::string("stdout")) {
+        std::string dir = line.substr(0, found);
+        found = dir.find_last_of("/\\");
+        bzero(dir_, sizeof(dir_));
+        strncpy(dir_, line.substr(0, found).c_str(), sizeof(dir_));
+        dir_[sizeof(dir_)] = 0;
+        printf("dir: %s\n", dir_);
         break;
       }
     }

--- a/hosted/src/NodeAllocator.cc
+++ b/hosted/src/NodeAllocator.cc
@@ -22,6 +22,7 @@ namespace bai = boost::asio::ip;
 int ebbrt::NodeAllocator::DefaultCpus;
 int ebbrt::NodeAllocator::DefaultRam;
 int ebbrt::NodeAllocator::DefaultNumaNodes;
+std::string ebbrt::NodeAllocator::DefaultArguments;
 
 ebbrt::NodeAllocator::Session::Session(bai::tcp::socket socket,
                                        uint32_t net_addr)
@@ -100,9 +101,13 @@ ebbrt::NodeAllocator::NodeAllocator() : node_index_(2), allocation_index_(0) {
     DefaultRam = (str) ? atoi(str) : kDefaultRam;
     str = getenv("EBBRT_NODE_ALLOCATOR_DEFAULT_NUMANODES");
     DefaultNumaNodes = (str) ? atoi(str) : kDefaultNumaNodes;
+    str  = getenv("EBBRT_NODE_ALLOCATOR_DEFAULT_ARGUMENTS");
+    DefaultArguments = (str) ? std::string(str) : std::string(" ");
+
     std::cout << "NodeAllocator::Init() DefaultCpus=" << DefaultCpus 
 	      << " DefaultNumaNodes=" << DefaultNumaNodes 
-	    << " DefaultRam=" << DefaultRam << std::endl;
+	    << " DefaultRam=" << DefaultRam 
+      << " DefaultArguments="<< DefaultArguments << std::endl;
   }
   auto acceptor = std::make_shared<bai::tcp::acceptor>(
       active_context->io_service_, bai::tcp::endpoint(bai::tcp::v4(), 0));
@@ -168,7 +173,8 @@ ebbrt::NodeAllocator::NodeDescriptor
 ebbrt::NodeAllocator::AllocateNode(std::string binary_path,
 				   int cpus,
 				   int numaNodes,
-				   int ram) 
+				   int ram, 
+           std::string arguments) 
 {
   auto fdt = Fdt();
   fdt.BeginNode("/");
@@ -215,6 +221,7 @@ ebbrt::NodeAllocator::AllocateNode(std::string binary_path,
 #ifndef NDEBUG
     " -g" +
 #endif
+    std::string(" ") + arguments +
     std::string(" ") + std::string(network) + " " +
     binary_path + " " + fname.native();
 

--- a/hosted/src/include/ebbrt/NodeAllocator.h
+++ b/hosted/src/include/ebbrt/NodeAllocator.h
@@ -21,6 +21,7 @@ class NodeAllocator : public StaticSharedEbb<NodeAllocator> {
   static int DefaultCpus;
   static int DefaultNumaNodes;
   static int DefaultRam;
+  static std::string DefaultArguments;
 
  public:
   static void InitDefaults();
@@ -42,7 +43,7 @@ class NodeAllocator : public StaticSharedEbb<NodeAllocator> {
   };
   NodeDescriptor AllocateNode(std::string binary_path, int cpus = DefaultCpus,
                               int numNodes = DefaultNumaNodes,
-                              int ram = DefaultRam);
+                              int ram = DefaultRam, std::string arguments=DefaultArguments);
   void FreeNode(uint16_t node_id);
 
  private:

--- a/hosted/src/include/ebbrt/NodeAllocator.h
+++ b/hosted/src/include/ebbrt/NodeAllocator.h
@@ -43,7 +43,8 @@ class NodeAllocator : public StaticSharedEbb<NodeAllocator> {
   };
   NodeDescriptor AllocateNode(std::string binary_path, int cpus = DefaultCpus,
                               int numNodes = DefaultNumaNodes,
-                              int ram = DefaultRam, std::string arguments=DefaultArguments);
+                              int ram = DefaultRam,
+                              std::string arguments = DefaultArguments);
   void FreeNode(uint16_t node_id);
 
  private:


### PR DESCRIPTION
This pull adds to the NodeAllocator the ability to accept a string of "custom" arguments when allocating a node. The current implementation of AlllocateNode appends this string as arguments to the underlying call to `kh alloc`. 

For example:
```
NA->AllocateNode(binary_path, cpus, numa, ram, "--pin 0,1" );
```
Argument string can also be specified at runtime:
```
$ EBBRT_NODE_ALLOCATOR_DEFAULT_ARGUMENTS="--pin 0,1" ./helloworld
```
