### PR TITLE
fix(NetIp): Trim excess padding of packet

### DIFF
--- a/baremetal/src/NetIp.cc
+++ b/baremetal/src/NetIp.cc
@@ -49,6 +49,8 @@ void ebbrt::NetworkManager::Interface::ReceiveIp(
   if (unlikely(packet_len < tot_len))
     return;
 
+  buf->TrimEnd(packet_len - tot_len);
+
   if (unlikely(ip_header.ComputeChecksum() != 0))
     return;
 


### PR DESCRIPTION
The Ipv4 header specifies the packet's total length. While we have been
checking that the packet is at least this long, we have not been
trimming off any excess. This caused an issue where padding was treated
as valid TCP data further downstream.