### PR TITLE
fix(PageAllocator): fix deadlock case

### DIFF
--- a/baremetal/src/PageAllocator.cc
+++ b/baremetal/src/PageAllocator.cc
@@ -77,6 +77,13 @@ ebbrt::PageAllocator& ebbrt::PageAllocator::HandleFault(EbbId id) {
 ebbrt::PageAllocator::PageAllocator(Nid nid) : nid_(nid) {}
 
 ebbrt::Pfn ebbrt::PageAllocator::AllocLocal(size_t order, uint64_t max_addr) {
+
+  // cause a stack allocator page fault first, to
+  // avoid deadlocking when calling malloc and
+  // stack faulting at the same time
+  int tmp;
+  asm volatile("movl -4096(%%rsp), %0;" : "=r"(tmp) : :);
+
   std::lock_guard<SpinLock> lock(lock_);
 
   FreePage* fp = nullptr;


### PR DESCRIPTION
Deadlock happens when malloc and stack handler page fault
gets called one after another. Malloc holds onto the lock
and when stack handler page fault tries to allocate
for the stack, the lock is not available. Fix for now
is to read some data from the next page to preemptively
cause stack handler page fault first.