### PR TITLE
fix(Messenger.h): set default value for preallocate_ member variable

### DIFF
--- a/baremetal/src/include/ebbrt/Messenger.h
+++ b/baremetal/src/include/ebbrt/Messenger.h
@@ -83,7 +83,7 @@ class Messenger : public StaticSharedEbb<Messenger>, public CacheAligned {
     std::unique_ptr<MutIOBuf>
     process_message_chain(std::unique_ptr<MutIOBuf> b);
 
-    uint32_t preallocate_;
+    uint32_t preallocate_{0};
     std::unique_ptr<ebbrt::MutIOBuf> buf_;
     ebbrt::Promise<Connection*> promise_;
   };


### PR DESCRIPTION
preallocate_ was initialized with random values and causing
buf_ to be used when it contains garbage values