### PR TITLE
Command-line arguments for back-end

### DIFF
--- a/baremetal/src/Multiboot.cc
+++ b/baremetal/src/Multiboot.cc
@@ -40,3 +40,7 @@ void ebbrt::multiboot::Reserve(Information* mbi) {
 
   // TODO(dschatz): reserve ELF section headers and others
 }
+
+const char* ebbrt::multiboot::CmdLine() {
+  return reinterpret_cast<const char*>(cmdline_addr_);
+}

--- a/baremetal/src/Runtime.cc
+++ b/baremetal/src/Runtime.cc
@@ -59,14 +59,6 @@ class Connection : public ebbrt::TcpHandler {
 }  // namespace
 
 void ebbrt::runtime::Init() {
-#if __EBBRT_ENABLE_FDT__
-  auto reader = boot_fdt::Get();
-  auto offset = reader.GetNodeOffset("/runtime");
-  auto ip = reader.GetProperty32(offset, "address");
-  auto port = reader.GetProperty16(offset, "port");
-  auto allocation_id = reader.GetProperty16(offset, "allocation_id");
-  auto addr = Ipv4Address(htonl(ip));
-#else
   auto cmdline = std::string(ebbrt::multiboot::CmdLine());
   auto host = std::string("host_addr=");
   auto loc = cmdline.find(host);
@@ -105,8 +97,6 @@ void ebbrt::runtime::Init() {
   auto nport = atoi(port.c_str());
   auto naddr = atoi(host.c_str());
   auto addr = Ipv4Address(htonl(naddr));
-#endif
-  kprintf("RUNTIME command line args: %u %u %u\n", naddr, nport, allocation_id);
 
   EventManager::EventContext context;
   NetworkManager::TcpPcb pcb;

--- a/baremetal/src/Runtime.cc
+++ b/baremetal/src/Runtime.cc
@@ -60,34 +60,31 @@ class Connection : public ebbrt::TcpHandler {
 
 void ebbrt::runtime::Init() {
   auto cmdline = std::string(ebbrt::multiboot::CmdLine());
-  auto host = std::string("host_addr=");
-  auto loc = cmdline.find(host);
+  auto loc = cmdline.find("host_addr=");
   if (loc == std::string::npos) {
     kabort("No host address found in command line\n");
   }
-  host = cmdline.substr((loc + host.size()));
+  auto host = cmdline.substr((loc + 10));
   auto gap = host.find(";");
   if (gap != std::string::npos) {
     host = host.substr(0, gap);
   }
 
-  auto port = std::string("host_port=");
-  loc = cmdline.find(port);
+  loc = cmdline.find("host_port=");
   if (loc == std::string::npos) {
     kabort("No host port found in command line\n");
   }
-  port = cmdline.substr((loc + port.size()));
+  auto port = cmdline.substr((loc + 10));
   gap = port.find(";");
   if (gap != std::string::npos) {
     port = port.substr(0, gap);
   }
 
-  auto idstr = std::string("allocid=");
-  loc = cmdline.find(idstr);
+  loc = cmdline.find("allocid=");
   if (loc == std::string::npos) {
     kabort("No allocation id found in command line\n");
   }
-  idstr = cmdline.substr((loc + idstr.size()));
+  auto idstr = cmdline.substr((loc + 8));
   gap = idstr.find(";");
   if (gap != std::string::npos) {
     idstr = idstr.substr(0, gap);

--- a/baremetal/src/Runtime.cc
+++ b/baremetal/src/Runtime.cc
@@ -12,8 +12,12 @@
 #include <ebbrt/EventManager.h>
 #include <ebbrt/GlobalIdMap.h>
 #include <ebbrt/Messenger.h>
+#include <ebbrt/Multiboot.h>
 #include <ebbrt/Net.h>
 #include <ebbrt/UniqueIOBuf.h>
+
+#include <cstdlib>
+#include <string>
 
 namespace ebbrt {
 namespace runtime {
@@ -26,7 +30,7 @@ uint32_t ebbrt::runtime::Frontend() { return frontend; }
 namespace {
 class Connection : public ebbrt::TcpHandler {
  public:
-  explicit Connection(ebbrt::NetworkManager::TcpPcb&& pcb,
+  explicit Connection(ebbrt::NetworkManager::TcpPcb&& pcb,  // NOLINT
                       ebbrt::EventManager::EventContext& context)
       : TcpHandler(std::move(pcb)), context_(context) {}
 
@@ -55,16 +59,58 @@ class Connection : public ebbrt::TcpHandler {
 }  // namespace
 
 void ebbrt::runtime::Init() {
+#if __EBBRT_ENABLE_FDT__
   auto reader = boot_fdt::Get();
   auto offset = reader.GetNodeOffset("/runtime");
   auto ip = reader.GetProperty32(offset, "address");
   auto port = reader.GetProperty16(offset, "port");
   auto allocation_id = reader.GetProperty16(offset, "allocation_id");
-
   auto addr = Ipv4Address(htonl(ip));
+#else
+  auto cmdline = std::string(ebbrt::multiboot::CmdLine());
+  auto host = std::string("host_addr=");
+  auto loc = cmdline.find(host);
+  if (loc == std::string::npos) {
+    kabort("No host address found in command line\n");
+  }
+  host = cmdline.substr((loc + host.size()));
+  auto gap = host.find(";");
+  if (gap != std::string::npos) {
+    host = host.substr(0, gap);
+  }
+
+  auto port = std::string("host_port=");
+  loc = cmdline.find(port);
+  if (loc == std::string::npos) {
+    kabort("No host port found in command line\n");
+  }
+  port = cmdline.substr((loc + port.size()));
+  gap = port.find(";");
+  if (gap != std::string::npos) {
+    port = port.substr(0, gap);
+  }
+
+  auto idstr = std::string("allocid=");
+  loc = cmdline.find(idstr);
+  if (loc == std::string::npos) {
+    kabort("No allocation id found in command line\n");
+  }
+  idstr = cmdline.substr((loc + idstr.size()));
+  gap = idstr.find(";");
+  if (gap != std::string::npos) {
+    idstr = idstr.substr(0, gap);
+  }
+
+  auto allocation_id = atoi(idstr.c_str());
+  auto nport = atoi(port.c_str());
+  auto naddr = atoi(host.c_str());
+  auto addr = Ipv4Address(htonl(naddr));
+#endif
+  kprintf("RUNTIME command line args: %u %u %u\n", naddr, nport, allocation_id);
+
   EventManager::EventContext context;
   NetworkManager::TcpPcb pcb;
-  pcb.Connect(addr, port);
+  pcb.Connect(addr, nport);
   auto connection = new Connection(std::move(pcb), context);
   connection->Install();
   event_manager->SaveContext(context);

--- a/baremetal/src/include/ebbrt/Multiboot.h
+++ b/baremetal/src/include/ebbrt/Multiboot.h
@@ -80,6 +80,7 @@ struct Module {
   uint32_t reserved;
 };
 
+const char* CmdLine();
 void Reserve(Information* mbi);
 
 extern uintptr_t cmdline_addr_;

--- a/hosted/src/include/ebbrt/NodeAllocator.h
+++ b/hosted/src/include/ebbrt/NodeAllocator.h
@@ -88,6 +88,7 @@ class NodeAllocator : public StaticSharedEbb<NodeAllocator> {
   std::string AllocateContainer(std::string repo,
                                 std::string container_args = std::string(),
                                 std::string run_cmd = std::string());
+  void AppendArgs(std::string arg);
   void FreeNode(std::string node_id);
 
  private:
@@ -110,6 +111,7 @@ class NodeAllocator : public StaticSharedEbb<NodeAllocator> {
   std::atomic<uint16_t> allocation_index_;
   std::unordered_map<uint16_t, Promise<Messenger::NetworkId>> promise_map_;
   std::string network_id_;
+  std::string cmdline_;
   uint32_t net_addr_;
   uint16_t port_;
   uint8_t cidr_;


### PR DESCRIPTION
Interfaces have been added to read the command-line field of the multiboot header. Node-allocator changed to pass the host variables (netid, port) via the command-line. FDT requirement removed. 