### PR TITLE
fix(build): Track patch change dependencies

### DIFF
--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -193,7 +193,8 @@ automake: automake-install
 
 ### Capnp ###
 
-$(CAPNPDEP_SRC_PATH): | $(CAPNPDEP_TAR_PATH) $(SRCDIR)
+$(CAPNPDEP_SRC_PATH): $(CAPNPDEP_PATCH_PATH) | $(CAPNPDEP_TAR_PATH) $(SRCDIR)
+	-$(RM) -r $(CAPNPDEP_SRC_PATH)
 	$(TAR) -xf $(CAPNPDEP_TAR_PATH) -C $(SRCDIR)
 	$(PATCH) -p1 -l -s -d $@ < $(CAPNPDEP_PATCH_PATH)
 
@@ -221,7 +222,8 @@ deps: autoconf automake capnpdep
 
 ### Binutils ###
 
-$(BINUTILS_SRC_PATH): | deps $(BINUTILS_TAR_PATH) $(SRCDIR)
+$(BINUTILS_SRC_PATH): $(BINUTILS_PATCH_PATH) | deps $(BINUTILS_TAR_PATH) $(SRCDIR)
+	-$(RM) -r $(BINUTILS_SRC_PATH)
 	$(TAR) -xf $(BINUTILS_TAR_PATH) -C $(SRCDIR)
 	$(PATCH) -p1 -l -s -d $@ < $(BINUTILS_PATCH_PATH)
 	cd $@/ld && $(AUTOMAKE)
@@ -248,7 +250,8 @@ binutils: binutils-install
 
 ### GCC ###
 
-$(GCC_SRC_PATH): | deps $(GCC_TAR_PATH) $(SRCDIR)
+$(GCC_SRC_PATH): $(GCC_PATCH_PATH) | deps $(GCC_TAR_PATH) $(SRCDIR)
+	-$(RM) -r $(GCC_SRC_PATH)
 	$(TAR) -xf $(GCC_TAR_PATH) -C $(SRCDIR)
 	$(CD) $@ && ./contrib/download_prerequisites
 	$(PATCH) -p1 -l -s -d $@ < $(GCC_PATCH_PATH) && \
@@ -287,7 +290,8 @@ gcc-all: gcc-all-install
 
 ### Newlib ###
 
-$(NEWLIB_SRC_PATH): | deps $(NEWLIB_TAR_PATH) $(SRCDIR)
+$(NEWLIB_SRC_PATH): $(NEWLIB_PATCH_PATH) | deps $(NEWLIB_TAR_PATH) $(SRCDIR)
+	-$(RM) -r $(NEWLIB_SRC_PATH)
 	$(TAR) -xf $(NEWLIB_TAR_PATH) -C $(SRCDIR)
 	$(PATCH) -p1 -l -s -d $@ < $(NEWLIB_PATCH_PATH) && \
 	$(CD) $@/newlib/libc/sys && $(AUTOCONF) && \


### PR DESCRIPTION
This commit modifies the toolchain Makefile to ensure that if any of the
patches change, we reconstruct the source directory of that part of the
toolchain.