### PR TITLE
[merged] fix(NodeAllocator): wait for node to initialize

### DIFF
--- a/docker/buildbot-slave/Dockerfile
+++ b/docker/buildbot-slave/Dockerfile
@@ -5,6 +5,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     clang-format-3.8 \
     git \
+    iputils-ping \
     python-dev \
     python-pexpect \
     python-pip \

--- a/hosted/src/NodeAllocator.cc
+++ b/hosted/src/NodeAllocator.cc
@@ -280,6 +280,7 @@ ebbrt::NodeAllocator::AllocateNode(std::string binary_path, int cpus,
 #endif
 
   /* transfer image into container */
+  RunCmd("ping -c 1 -w 30 " + cip);
   RunCmd("scp -q -o UserKnownHostsFile=/dev/null -o "
          "StrictHostKeyChecking=no " +
          binary_path + " root@" + cip + ":/root/img.elf");


### PR DESCRIPTION
Wait for the node's network to be reachable before attempting to send over the back-end image

Timeout set at 30 seconds