### PR TITLE
[merged] fix(build): Ensure CMAKE_INSTALL_PREFIX is set

### DIFF
--- a/baremetal/cmake/ebbrt.cmake
+++ b/baremetal/cmake/ebbrt.cmake
@@ -10,6 +10,7 @@ endif()
 
 # where is the target environment
 SET(CMAKE_SYSROOT  $ENV{EBBRT_SYSROOT})
+SET(CMAKE_INSTALL_PREFIX "${CMAKE_SYSROOT}/usr" CACHE PATH "default install path" FORCE )
 
 # specify the cross compiler
 SET(CMAKE_C_COMPILER   ${CMAKE_SYSROOT}/usr/bin/x86_64-pc-ebbrt-gcc)


### PR DESCRIPTION
Versions of cmake older than 3.0.2 do not respect the CMAKE_SYSROOT
variable for setting the INSTALL_PREFIX. This commit ensures that the
variable is set correctly.