### PR TITLE
[merged] Support out-of-order TCP segments

### DIFF
--- a/src/native/Net.h
+++ b/src/native/Net.h
@@ -152,6 +152,7 @@ class NetworkManager : public StaticSharedEbb<NetworkManager> {
     std::tuple<Ipv4Address, uint16_t, uint16_t> key;
     boost::container::list<TcpSegment> unacked_segments;
     boost::container::list<TcpSegment> pending_segments;
+    std::map<uint32_t, std::unique_ptr<IOBuf>> stashed_segments;
     enum State {
       kClosed,
       kSynSent,

--- a/src/native/NetTcp.cc
+++ b/src/native/NetTcp.cc
@@ -782,7 +782,6 @@ bool ebbrt::NetworkManager::TcpEntry::Receive(
               if (it->first == rcv_nxt + payload_len) {
                 payload_len += (it->second)->ComputeChainDataLength();
                 buf->PrependChain(std::move(it->second));
-                auto sanity = buf->ComputeChainDataLength();
                 it = stashed_segments.erase(it);
               } else {
                 ++it;


### PR DESCRIPTION
We previously dropped all out-of-order segments, this patch adds a cache-and-restore feature for segments that fall within the receive windows [RFC 793 pg,69].