### PR TITLE
[merged] refactor(idt): weak exception/interrupt symbols

### DIFF
--- a/src/native/Idt.h
+++ b/src/native/Idt.h
@@ -38,24 +38,24 @@ struct ExceptionFrame {
 void Init();
 void Load();
 extern "C" __attribute__((noreturn)) void EventInterrupt(int num);
-extern "C" void NmiInterrupt(ExceptionFrame* ef);
-extern "C" void DivideErrorException(ExceptionFrame* ef);
-extern "C" void DebugException(ExceptionFrame* ef);
-extern "C" void BreakpointException(ExceptionFrame* ef);
-extern "C" void OverflowException(ExceptionFrame* ef);
-extern "C" void BoundRangeExceededException(ExceptionFrame* ef);
-extern "C" void InvalidOpcodeException(ExceptionFrame* ef);
-extern "C" void DeviceNotAvailableException(ExceptionFrame* ef);
-extern "C" void DoubleFaultException(ExceptionFrame* ef);
-extern "C" void InvalidTssException(ExceptionFrame* ef);
-extern "C" void SegmentNotPresent(ExceptionFrame* ef);
-extern "C" void StackFaultException(ExceptionFrame* ef);
-extern "C" void GeneralProtectionException(ExceptionFrame* ef);
-extern "C" void PageFaultException(ExceptionFrame* ef);
-extern "C" void X87FpuFloatingPointError(ExceptionFrame* ef);
-extern "C" void AlignmentCheckException(ExceptionFrame* ef);
-extern "C" void MachineCheckException(ExceptionFrame* ef);
-extern "C" void SimdFloatingPointException(ExceptionFrame* ef);
+extern "C" void NmiInterrupt(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void DivideErrorException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void DebugException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void BreakpointException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void OverflowException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void BoundRangeExceededException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void InvalidOpcodeException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void DeviceNotAvailableException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void DoubleFaultException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void InvalidTssException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void SegmentNotPresent(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void StackFaultException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void GeneralProtectionException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void PageFaultException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void X87FpuFloatingPointError(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void AlignmentCheckException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void MachineCheckException(ExceptionFrame* ef) __attribute__((weak));
+extern "C" void SimdFloatingPointException(ExceptionFrame* ef) __attribute__((weak));
 }  // namespace idt
 }  // namespace ebbrt
 


### PR DESCRIPTION
Changed all our standard entry points for exceptions and interrupts
into weak symbols so that application/library code can overide
them.  These are the symbols that can now be over ridden can
be found in idt.h