### PR TITLE
chore(build): Root-lvl Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,95 @@
+# Build and Install the EbbRT Toolchain & EbbLib (Linux) Library
+#
+# This Makefile provides a convenient way build and install the EbbRT "native"
+# toolchain and "hosted" Linux libraries. 
+#
+# example: 
+# 	$ make -f ~/EbbRT/Makefile -j=12 VERBOSE=1
+#
+# Options:
+# 	DEBUG=1 						# build without optimisation
+# 	CLEANUP=1     			# remove build state when finished
+# 	PREFIX=<path> 			# install directory [=$PWD] 
+# 	BUILD_ROOT					# build directory [=$PREFIX/build]
+# 	EBBRT_SRCDIR=<path> # EbbRT source repository [=$HOME/EbbRT]
+# 	VERBOSE=1   				# verbose build 
+#
+# Targets: 
+# 	hosted native ebbrt-only clean 
+
+-include config.mk # Local config (optional)
+
+MYDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+MKROOT ?= $(abspath $(CURDIR))
+MYHOME ?= $(abspath $(HOME))
+THISFILE := $(MYDIR)/Makefile
+CD ?= cd
+CMAKE ?= cmake
+MAKE ?= time make
+MKDIR ?= mkdir
+RM ?= -rm
+TEST ?= test
+
+EBBRT_SRCDIR ?= $(MYDIR)
+ifeq "$(wildcard $(EBBRT_SRCDIR) )" ""
+  $(error Unable to locate source EBBRT_SRCDIR=$(EBBRT_SRCDIR))
+endif
+EBBRT_SRC ?= $(EBBRT_SRCDIR)/src
+EBBRT_MAKEFILE ?= $(EBBRT_SRCDIR)/toolchain/Makefile
+
+PREFIX ?= $(abspath $(CURDIR))
+INSTALL_ROOT ?= $(PREFIX)
+BUILD_ROOT ?= $(PREFIX)/build
+NATIVE_INSTALL_PATH ?= $(INSTALL_ROOT)/sysroot
+HOSTED ?= $(INSTALL_ROOT)/hosted
+HOSTED_BUILD_DIR ?= $(BUILD_ROOT)/hosted
+NATIVE_BUILD_DIR ?= $(BUILD_ROOT)/native
+
+ifdef CLEANUP
+CLEANUP ?= $(RM) -rf  
+else
+CLEANUP ?= $(TEST)
+endif
+
+ifdef DEBUG
+CMAKE_BUILD_OPT ?= -DCMAKE_BUILD_TYPE=Debug
+MAKE_BUILD_OPT ?= DEBUG=1
+else
+CMAKE_BUILD_OPT ?= -DCMAKE_BUILD_TYPE=Release
+MAKE_BUILD_OPT ?= 
+endif
+
+ifdef VERBOSE
+MAKE_VERBOSE_OPT ?= VERBOSE=1
+CMAKE_VERBOSE_OPT ?= -DCMAKE_VERBOSE_MAKEFILE=On
+else
+MAKE_VERBOSE_OPT ?= 
+CMAKE_VERBOSE_OPT ?= 
+endif
+
+all: hosted native 
+
+clean:
+	$(MAKE) -C $(HOSTED_BUILD_DIR) clean
+	$(MAKE) -C $(NATIVE_BUILD_DIR) clean
+
+hosted: | $(EBBRT_SRC)
+	$(MKDIR) -p $(HOSTED_BUILD_DIR) && $(CD) $(HOSTED_BUILD_DIR) && \
+	$(CMAKE) -DCMAKE_INSTALL_PREFIX=$(HOSTED) $(EBBRT_SRC) \
+	$(CMAKE_BUILD_TYPE) $(CMAKE_VERBOSE_OPT) && \
+	$(MAKE) $(MAKE_OPT) install && \
+	$(CD) - && \
+	$(CLEANUP) $(HOSTED_BUILD_DIR)
+	
+native: | $(EBBRT_MAKEFILE)
+	$(MKDIR) -p $(NATIVE_BUILD_DIR) && $(CD) $(NATIVE_BUILD_DIR) && \
+	$(MAKE) $(MAKE_OPT) -f $(EBBRT_MAKEFILE) SYSROOT=$(NATIVE_INSTALL_PATH) \
+	$(MAKE_BUILD_TYPE) $(MAKE_VERBOSE_OPT) && $(CD) - && \
+	$(CLEANUP) $(NATIVE_BUILD_DIR)
+
+ebbrt-only: | $(EBBRT_MAKEFILE)
+	$(MKDIR) -p $(NATIVE_BUILD_DIR) && $(CD) $(NATIVE_BUILD_DIR) && \
+	$(MAKE) -f $(EBBRT_MAKEFILE) SYSROOT=$(NATIVE_INSTALL_PATH) \
+	$(MAKE_BUILD_TYPE) $(MAKE_VERBOSE_OPT) ebbrt-only && $(CD) - 
+
+.PHONY: all clean hosted native ebbrt-only 

--- a/src/hosted/config.cmake
+++ b/src/hosted/config.cmake
@@ -1,5 +1,9 @@
 # EbbRT hosted platform-specific configuration
-add_compile_options(-std=gnu++14 -Wall -Werror)
+set(CMAKE_CXX_FLAGS                "-Wall -Werror -std=gnu++14")
+set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g3")
+set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE        "-O4 -flto -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g3")
 
 find_package(Boost 1.53.0 REQUIRED COMPONENTS 
   filesystem system coroutine context )

--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -3,7 +3,6 @@ MYDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 -include config.mk
 
 TARGET ?= x86_64-pc-ebbrt
-
 AUTOCONF_VERSION ?= 2.64
 AUTOMAKE_VERSION ?= 1.11.1
 BINUTILS_VERSION ?= 2.26
@@ -90,22 +89,30 @@ NEWLIB_CONFIGURE_FLAG ?= $(NEWLIB_BUILD_PATH)/Makefile
 ifdef DEBUG
 NEWLIB_CFLAGS ?= "-O0 -g3"
 else
-NEWLIB_CFLAGS ?= "-O4" # FIXME: Link Time Optimization fails
+NEWLIB_CFLAGS ?= "-O4" 
 endif
-
 
 EBBRT_BM_PATH ?= $(EBBRT_SRCDIR)/src/native
 EBBRT_BUILD_PATH ?= $(BUILDDIR)/ebbrt-build
 EBBRT_CONFIGURE_FLAG ?= $(EBBRT_BUILD_PATH)/Makefile
-
 CMAKE_TOOLCHAIN_FILE ?= $(EBBRT_SRCDIR)/src/cmake/ebbrt.cmake
+
 ifdef DEBUG
-CMAKE_OPT ?= -DCMAKE_BUILD_TYPE=Debug
+CMAKE_BUILD_TYPE ?= -DCMAKE_BUILD_TYPE=Debug
 else
-CMAKE_OPT ?= -DCMAKE_BUILD_TYPE=Release
+CMAKE_BUILD_TYPE ?= -DCMAKE_BUILD_TYPE=Release
 endif
+
+ifdef VERBOSE
+CMAKE_VERBOSE_OPT ?= -DCMAKE_VERBOSE_MAKEFILE=On
+else
+CMAKE_VERBOSE_OPT ?= 
+endif
+
 CMAKE_DEFS ?= -DCMAKE_INSTALL_PREFIX:PATH=$(PREFIX) \
-	-DCMAKE_TOOLCHAIN_FILE=$(CMAKE_TOOLCHAIN_FILE) $(CMAKE_OPT)
+	-DCMAKE_TOOLCHAIN_FILE=$(CMAKE_TOOLCHAIN_FILE) \
+	$(CMAKE_BUILD_TYPE) $(CMAKE_VERBOSE_OPT)
+
 EBBRT_BUILD_DEFS ?= -DCMAKE_C_COMPILER_FORCED=1 \
 										-DCMAKE_CXX_COMPILER_FORCED=1
 
@@ -322,7 +329,6 @@ newlib-install: newlib-build
 		RANLIB_FOR_TARGET=x86_64-pc-ebbrt-gcc-ranlib \
 		$(MAKE) install -C $(NEWLIB_BUILD_PATH)
 
-
 newlib: newlib-install
 
 ### ACPICA ###
@@ -421,11 +427,13 @@ ebbrt-headers: | $(PREFIX)/include/ebbrt/native
 ebbrt-cmake: | $(PREFIX)/misc
 	$(CP) -v $(CMAKE_TOOLCHAIN_FILE) $(PREFIX)/misc
 
-###
+ebbrt-only: | $(EBBRT_BUILD_PATH)
+	$(MAKE) -C $(EBBRT_BUILD_PATH) install
+
 
 .PHONY: all autoconf autoconf-build autoconf-install automake automake-build \
 	automake-install binutils binutils-build binutils-install clean deps \
 	gcc gcc-build gcc-install gcc-all gcc-all-build gcc-all-install newlib \
 	newlib-build newlib-install acpica-build acpica-install boost-build \
 	boost-install capnp-build capnp-install tbb-build tbb-install \
-	ebbrt-deps ebbrt-build ebbrt-install ebbrt-cmake
+	ebbrt-deps ebbrt-build ebbrt-install ebbrt-cmake ebbrt-only


### PR DESCRIPTION
Adds a root-level Makefile that builds and installs the sysroot and hosted libraries.

Adds an 'ebbrt-only' target to fast-path the rebuilding of the EbbRT (native) library without first checking the long list of toolchain dependencies.