### PR TITLE
[merged] chore(build): root-lvl make builds EbbRT libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ clean:
 
 hosted: | $(EBBRT_SRC)
 	$(MKDIR) -p $(HOSTED_BUILD_DIR) && $(CD) $(HOSTED_BUILD_DIR) && \
-	$(CMAKE) -DCMAKE_INSTALL_PREFIX=$(HOSTED) $(EBBRT_SRC) \
-	$(CMAKE_BUILD_TYPE) $(CMAKE_VERBOSE_OPT) && \
+	$(CMAKE) -DCMAKE_INSTALL_PREFIX=$(HOSTED)  \
+	$(CMAKE_BUILD_OPT) $(CMAKE_VERBOSE_OPT) $(EBBRT_SRC) && \
 	$(MAKE) $(MAKE_OPT) install && \
 	$(CD) - && \
 	$(CLEANUP) $(HOSTED_BUILD_DIR)
@@ -86,7 +86,7 @@ hosted: | $(EBBRT_SRC)
 native: | $(EBBRT_MAKEFILE)
 	$(MKDIR) -p $(NATIVE_BUILD_DIR) && $(CD) $(NATIVE_BUILD_DIR) && \
 	$(MAKE) $(MAKE_OPT) -f $(EBBRT_MAKEFILE) SYSROOT=$(NATIVE) \
-	$(MAKE_BUILD_TYPE) $(MAKE_VERBOSE_OPT) && $(CD) - && \
+	$(MAKE_BUILD_OPT) $(MAKE_VERBOSE_OPT) && $(CD) - && \
 	$(CLEANUP) $(NATIVE_BUILD_DIR)
 
 ebbrt-libs: ebbrt-native-libs ebbrt-hosted-libs
@@ -94,19 +94,19 @@ ebbrt-libs: ebbrt-native-libs ebbrt-hosted-libs
 ebbrt-hosted-libs: hosted 
 	$(CD) $(HOSTED_BUILD_DIR) && $(MKDIR) -p libs && $(CD) libs && \
 	$(CMAKE) -DCMAKE_INSTALL_PREFIX=$(HOSTED)  \
-	$(CMAKE_BUILD_TYPE) $(CMAKE_VERBOSE_OPT) $(EBBRT_LIBS) && \
+	$(CMAKE_BUILD_OPT) $(CMAKE_VERBOSE_OPT) $(EBBRT_LIBS) && \
 	$(MAKE) $(MAKE_OPT) install && $(CD) - 
 	
 ebbrt-native-libs: native 
 	$(CD) $(NATIVE_BUILD_DIR) && $(MKDIR) -p libs && $(CD) libs && \
 	EBBRT_SYSROOT=$(NATIVE) $(CMAKE) -DCMAKE_INSTALL_PREFIX=$(NATIVE) \
 	-DCMAKE_TOOLCHAIN_FILE=$(NATIVE_TOOLCHAIN_FILE) \
-	$(CMAKE_BUILD_TYPE) $(CMAKE_VERBOSE_OPT) $(EBBRT_LIBS) && \
+	$(CMAKE_BUILD_OPT) $(CMAKE_VERBOSE_OPT) $(EBBRT_LIBS) && \
 	$(MAKE) $(MAKE_OPT) install && $(CD) - 
 
 ebbrt-only: | $(EBBRT_MAKEFILE)
 	$(MKDIR) -p $(NATIVE_BUILD_DIR) && $(CD) $(NATIVE_BUILD_DIR) && \
 	$(MAKE) -f $(EBBRT_MAKEFILE) SYSROOT=$(NATIVE) \
-	$(MAKE_BUILD_TYPE) $(MAKE_VERBOSE_OPT) ebbrt-only && $(CD) - 
+	$(MAKE_BUILD_OPT) $(MAKE_VERBOSE_OPT) ebbrt-only && $(CD) - 
 
 .PHONY: all clean hosted native ebbrt-only 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.6)
+project(EbbRT-libs CXX ASM)
+
+# EbbRT Library to build by default
+set(subdirs
+  cmdline
+  filesystem
+  socket
+)
+foreach(subdir ${subdirs})
+  add_subdirectory(${subdir})
+endforeach()

--- a/libs/cmdline/CMakeLists.txt
+++ b/libs/cmdline/CMakeLists.txt
@@ -3,7 +3,7 @@ project("ebbrt-cmdline" CXX)
 cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 include(CMakePackageConfigHelpers)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g3")
 set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE        "-O4 -flto -DNDEBUG")
@@ -21,7 +21,7 @@ if( ${CMAKE_SYSTEM_NAME} STREQUAL "EbbRT")
 endif()
 
 set(capnp_sources
-  ${CMAKE_SOURCE_DIR}/CmdLineArgs.capnp
+  ${CMAKE_CURRENT_SOURCE_DIR}/CmdLineArgs.capnp
 )
 
 include_directories(${CAPNP_INCLUDE_DIRS})
@@ -29,7 +29,7 @@ include_directories(${EBBRT_INCLUDE_DIRS})
 
 add_definitions(${CAPNP_DEFINITIONS})
 set(CAPNPC_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
-set(CAPNPC_SRC_PREFIX ${CMAKE_SOURCE_DIR})
+set(CAPNPC_SRC_PREFIX ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CAPNPC_OUTPUT_DIR})
 capnp_generate_cpp(CapnpSources CapnpHeaders ${capnp_sources})
 
@@ -54,20 +54,13 @@ set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
 set(INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
 set(INSTALL_INCLUDE_DIR include CACHE PATH
   "Installation directory for header files")
-if(WIN32 AND NOT CYGWIN)
-  set(DEF_INSTALL_CMAKE_DIR CMake)
-else()
-  set(DEF_INSTALL_CMAKE_DIR lib/cmake/EbbRTCmdLine)
-endif()
-set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
-  "Installation directory for CMake files")
 
 configure_package_config_file(EbbRTCmdLineConfig.cmake.in
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/EbbRTCmdLineConfig.cmake"
-  INSTALL_DESTINATION ${INSTALL_CMAKE_DIR}
+  INSTALL_DESTINATION lib/cmake/EbbRTCmdLine
   PATH_VARS INSTALL_INCLUDE_DIR INSTALL_LIB_DIR
 )
 
 install(FILES
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/EbbRTCmdLineConfig.cmake"
-  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+  DESTINATION "lib/cmake/EbbRTCmdLine" COMPONENT dev)

--- a/libs/filesystem/CMakeLists.txt
+++ b/libs/filesystem/CMakeLists.txt
@@ -3,7 +3,7 @@ project("ebbrt-filesystem" CXX)
 cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 include(CMakePackageConfigHelpers)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g3")
 set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE        "-O4 -flto -DNDEBUG")
@@ -21,7 +21,7 @@ if( ${CMAKE_SYSTEM_NAME} STREQUAL "EbbRT")
 endif()
 
 set(capnp_sources
-  ${CMAKE_SOURCE_DIR}/FileSystem.capnp
+  ${CMAKE_CURRENT_SOURCE_DIR}/FileSystem.capnp
 )
 
 include_directories(${CAPNP_INCLUDE_DIRS})
@@ -29,7 +29,7 @@ include_directories(${EBBRT_INCLUDE_DIRS})
 
 add_definitions(${CAPNP_DEFINITIONS})
 set(CAPNPC_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
-set(CAPNPC_SRC_PREFIX ${CMAKE_SOURCE_DIR})
+set(CAPNPC_SRC_PREFIX ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CAPNPC_OUTPUT_DIR})
 capnp_generate_cpp(CapnpSources CapnpHeaders ${capnp_sources})
 
@@ -54,20 +54,13 @@ set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
 set(INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
 set(INSTALL_INCLUDE_DIR include CACHE PATH
   "Installation directory for header files")
-if(WIN32 AND NOT CYGWIN)
-  set(DEF_INSTALL_CMAKE_DIR CMake)
-else()
-  set(DEF_INSTALL_CMAKE_DIR lib/cmake/EbbRTFilesystem)
-endif()
-set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
-  "Installation directory for CMake files")
 
 configure_package_config_file(EbbRTFilesystemConfig.cmake.in
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/EbbRTFilesystemConfig.cmake"
-  INSTALL_DESTINATION ${INSTALL_CMAKE_DIR}
+  INSTALL_DESTINATION lib/cmake/EbbRTFilesystem
   PATH_VARS INSTALL_INCLUDE_DIR INSTALL_LIB_DIR
 )
 
 install(FILES
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/EbbRTFilesystemConfig.cmake"
-  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+  DESTINATION "lib/cmake/EbbRTFilesystem" COMPONENT dev)

--- a/libs/socket/CMakeLists.txt
+++ b/libs/socket/CMakeLists.txt
@@ -13,7 +13,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14")
 if( ${CMAKE_SYSTEM_NAME} STREQUAL "EbbRT")
   message(STATUS "System name: ${CMAKE_SYSTEM_NAME}")
 else()
-  message(FATAL_ERROR "System name unsupported: ${CMAKE_SYSTEM_NAME}")
+  message(WARNING "System name unsupported: ${CMAKE_SYSTEM_NAME}")
+  return()
 endif()
 
 # Library targets
@@ -41,8 +42,6 @@ set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
 set(INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
 set(INSTALL_INCLUDE_DIR include CACHE PATH
   "Installation directory for header files")
-set(INSTALL_CMAKE_DIR lib/cmake/EbbRTSocket CACHE PATH
-  "Installation directory for CMake files")
 set(INSTALL_LWIP_INCLUDE_DIR include/ebbrt-socket/lwip/include CACHE PATH
   "Installation directory for lwip headers ")
 set(INSTALL_POSIX_INCLUDE_DIR include/ebbrt-socket/lwip/include/posix CACHE PATH
@@ -67,10 +66,10 @@ install( DIRECTORY ${PROJECT_SOURCE_DIR}/lwip DESTINATION
 # Package config file
 configure_package_config_file(EbbRTSocketConfig.cmake.in
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/EbbRTSocketConfig.cmake"
-  INSTALL_DESTINATION ${INSTALL_CMAKE_DIR} 
+  INSTALL_DESTINATION lib/cmake/EbbRTSocket 
   PATH_VARS INSTALL_INCLUDE_DIR INSTALL_LWIP_INCLUDE_DIR
   INSTALL_POSIX_INCLUDE_DIR  INSTALL_GNU_INCLUDE_DIR INSTALL_LIB_DIR
 )
 install(FILES
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/EbbRTSocketConfig.cmake"
-  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+  DESTINATION "lib/cmake/EbbRTSocket" COMPONENT dev)

--- a/src/Hash.h
+++ b/src/Hash.h
@@ -5,6 +5,8 @@
 #ifndef COMMON_SRC_INCLUDE_EBBRT_HASH_H_
 #define COMMON_SRC_INCLUDE_EBBRT_HASH_H_
 
+#include <stdexcept>
+
 namespace ebbrt {
 namespace hash {
 

--- a/src/hosted/config.cmake
+++ b/src/hosted/config.cmake
@@ -2,7 +2,7 @@
 set(CMAKE_CXX_FLAGS                "-Wall -Werror -std=gnu++14")
 set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g3")
 set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELEASE        "-O4 -flto -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE        "-O4 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g3")
 
 find_package(Boost 1.53.0 REQUIRED COMPONENTS 


### PR DESCRIPTION
The command `make -j -f ~/EbbRT/Makefile` will build and install front-end and native EbbRT along with the cmdlne, filesystem, and socket libraries. (`make -j -f ~/EbbRT/Makefile DEBUG=1` for a debug build)